### PR TITLE
Supports latest nim devel

### DIFF
--- a/tests/test_any.nim
+++ b/tests/test_any.nim
@@ -40,7 +40,7 @@ proc toBinary(s: string): string =
 proc toHex*(s: string): string =
   result = newStringOfCap(s.len * 2)
   for c in s:
-    result.add toHex(c)
+    result.add toHex(c.ord)
 
 proc cmp(a: MsgAny, b: string): bool =
   let msg = fromAny(a)
@@ -252,4 +252,3 @@ test "bin and ext":
   check a_arr[0].binData == "binary data"
   check a_arr[1].extType == extType
   check a_arr[1].extData == "ext oi..."
-

--- a/tests/test_any.nim
+++ b/tests/test_any.nim
@@ -61,7 +61,7 @@ test "positive int":
   check cmp(anyUInt(255), "ccff")
   check cmp(anyUInt(256), "cd0100")
   check cmp(anyUInt(65535), "cdffff")
-  check cmp(anyUInt(uint64(high(uint32) + 1)), "CF0000000100000000")
+  check cmp(anyUInt(uint64(high(uint32)) + 1), "CF0000000100000000")
 
 test "negative int":
   check cmp(anyInt(-1), "FF")

--- a/tests/test_json.nim
+++ b/tests/test_json.nim
@@ -19,7 +19,7 @@ proc toBinary(s: string): string =
 proc toHex*(s: string): string =
   result = newStringOfCap(s.len * 2)
   for c in s:
-    result.add toHex(c)
+    result.add toHex(c.ord)
 
 proc cmp(a: JsonNode, b: string): bool =
   let msg = fromJsonNode(a)

--- a/tests/test_json.nim
+++ b/tests/test_json.nim
@@ -40,7 +40,7 @@ test "positive int":
   check cmp(newJInt(255), "ccff")
   check cmp(newJInt(256), "cd0100")
   check cmp(newJInt(65535), "cdffff")
-  check cmp(newJInt(BiggestInT(high(uint32) + 1)), "CF0000000100000000")
+  check cmp(newJInt(BiggestInT(high(uint32)) + 1), "CF0000000100000000")
 
 test "negative int":
   check cmp(newJInt(-1), "FF")

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -40,7 +40,7 @@ test "positive int":
   check cmp(pack(255), "ccff")
   check cmp(pack(256), "cd0100")
   check cmp(pack(65535), "cdffff")
-  check cmp(pack(uint64(high(uint32) + 1)), "CF0000000100000000")
+  check cmp(pack(uint64(high(uint32)) + 1), "CF0000000100000000")
 
 test "negative int":
   check cmp(pack(-1), "FF")

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -19,7 +19,7 @@ proc toBinary(s: string): string =
 proc toHex*(s: string): string =
   result = newStringOfCap(s.len * 2)
   for c in s:
-    result.add toHex(c)
+    result.add toHex(c.ord)
 
 proc cmp(a, b: string): bool =
   result = a == toBinary(b)


### PR DESCRIPTION
I had to change 2 things to make things work in the latest `devel` (Sept 23, 2018).  These are also compatible with stable `0.18.0`.

### toHex

There was a recent change [issue](https://github.com/nim-lang/Nim/issues/8865) and [commit](https://github.com/nim-lang/Nim/commit/36e6ca16d1ece106d88fbb951b544b80c360d600) to `toHex` which will only play nice with Integers.  Iterating over strings in `for` loops yields `char`s, so the compiler is angry.

### Conversion Order of Operations

This was a head scratcher.

This fixes your `int32 + 1` conversion check.  The new behaviour (in order of operations???) seems to wrap to 0... unless we change to a int64 earlier.  My change might be breaking the spirit of that check, so I apologize if that's the case.  

FWIW I've only tested on `Ubuntu 18.04 64bit` cuz I gotta rush to supper.  :chicken: 

