### PR TITLE
Fix nimble install

### DIFF
--- a/msgpack4nim.nimble
+++ b/msgpack4nim.nimble
@@ -7,6 +7,8 @@ license       = "MIT"
 # Dependencies
 requires "nim >= 0.18.0"
 
+installFiles = @["msgpack4nim.nim", "msgpack4collection.nim", "msgpack2any.nim", "msgpack2json.nim"]
+
 # Examples and Tests
 skipDirs = @["examples", "tests"]
 


### PR DESCRIPTION
* https://github.com/nim-lang/nimble

> If your package exposes only a single module, then that module should be present in the root directory ... and should be named whatever your package's name is.

> If your package exposes multiple modules then the modules should be in a PackageName directory. This will allow for a certain measure of isolation from other packages which expose modules with the same names. In this case the package's modules will be imported with import PackageName/module.

You might think you could use`installDirs`:
```nim
installDirs = @["."]
```
But that will install the `tests/` and `examples/` dirs too, despite `skipDirs`. You need `installExt`. This PR gives:
```
% nimble install --nimbleDir:$N
% ls $N/pkgs/msgpack4nim-0.2.8/
msgpack2any.nim  msgpack2json.nim  msgpack4collection.nim  msgpack4nim.nim  msgpack4nim.nimble  nimblemeta.json
```
As an alternative, you could simply switch to the new way, by moving `*.nim` into a sub-directory.