### PR TITLE
compatibility

### DIFF
--- a/msgpack4nim.nim
+++ b/msgpack4nim.nim
@@ -127,7 +127,7 @@ proc conversionError*(msg: string): ref ObjectConversionError =
 
 template skipUndistinct* {.pragma.}
 
-proc needToSkip(typ: typedesc): bool {.compileTime.} =
+proc needToSkip(typ: NimNode | typedesc): bool {.compileTime.} =
   let z = getType(typ)[1]
   if z.kind != nnkSym: return false
   let impl = getImpl(z)


### PR DESCRIPTION
typedesc is now passed to macros as ``NimNode``, apart from that it works as before. This minimal code change should work for both old and new version of Nim. In the future `` | typedesc`` part can be removed.

This change is necesary to make the make the CI in this PR green: https://github.com/nim-lang/Nim/pull/11400