### PR TITLE
fix outdir for nim PR

### DIFF
--- a/msgpack4nim.nimble
+++ b/msgpack4nim.nimble
@@ -21,6 +21,7 @@ task test, "Run all tests":
 
   exec "nim c -d:release -r examples/test"
   exec "nim c -d:release -r -d:msgpack_obj_to_map tests/test_any"
-  exec "nim c -d:release -r tests/test_json"
+  # because uses `getAppDir()`, see https://github.com/nim-lang/Nim/pull/13382
+  exec "nim c -d:release -r --outdir:'$projectdir' tests/test_json"
   exec "nim c -d:release -r tests/test_codec"
   exec "nim c -d:release -r tests/test_spec"


### PR DESCRIPTION
/cc @jangko 
seems like this is the only nimble package that fails for this nim PR: https://github.com/nim-lang/Nim/pull/13382
after this fix, https://github.com/nim-lang/Nim/pull/13382 should have its CI pass

let me know if you have any questions