### PR TITLE
fix outdir for windows (for good this time...)

### DIFF
--- a/msgpack4nim.nimble
+++ b/msgpack4nim.nimble
@@ -12,20 +12,22 @@ installFiles = @["msgpack4nim.nim", "msgpack4collection.nim", "msgpack2any.nim",
 # Examples and Tests
 skipDirs = @["examples", "tests"]
 
+template exec(cmd) =
+  echo cmd
+  system.exec(cmd)
+
 task test, "Run all tests":
   exec "nim c -r examples/test"
   exec "nim c -r -d:msgpack_obj_to_map tests/test_any"
-  exec "nim c -r tests/test_json"
+  # because uses `getAppDir()`, see https://github.com/nim-lang/Nim/pull/13382
+  exec "nim c -r --outdir:tests tests/test_json"
   exec "nim c -r tests/test_codec"
   exec "nim c -r tests/test_spec"
 
   exec "nim c -d:release -r examples/test"
   exec "nim c -d:release -r -d:msgpack_obj_to_map tests/test_any"
-
-  # because uses `getAppDir()`, see https://github.com/nim-lang/Nim/pull/13382
-  exec "nim c -d:release tests/test_json"
-  when defined(windows): exec r"tests\test_json.exe"
-  else: exec r"tests/test_json"
+  # ditto
+  exec "nim c -d:release --outdir:tests tests/test_json"
 
   exec "nim c -d:release -r tests/test_codec"
   exec "nim c -d:release -r tests/test_spec"


### PR DESCRIPTION
sorry for the noise @jangko, looks like the previous attempts didn't work; I've now bitten the bullet and found a windows VM to test this on and make sure it all works; and for extra check I've added this to https://github.com/nim-lang/Nim/pull/13382 to make sure PR is green with this change:
```nim
pkg "msgpack4nim", "sh -c 'git checkout pr_fix_outdir3 && nimble test'", url = "https://github.com/timotheecour/msgpack4nim"
```

**so let's wait for nim CI https://github.com/nim-lang/Nim/pull/13382 to be green** before merging this, then I'll undo the above line from the nim PR.

## note
* `--outdir:'$projectdir'` unfortunately doesn't seem to work on windows (this shouldn't be hard to fix in Nim); so I'm using `--outdir:tests` here


