### PR TITLE
fix unpack null

### DIFF
--- a/msgpack4nim.nim
+++ b/msgpack4nim.nim
@@ -1122,7 +1122,9 @@ proc unpack_type*[ByteStream; T: tuple|object](s: ByteStream, val: var T) =
     dry_and_wet()
 
 proc unpack_type*[ByteStream; T: ref](s: ByteStream, val: var T) =
-  if s.peekChar == pack_value_nil: return
+  if s.peekChar == pack_value_nil:
+    s.skip_msg()
+    return
   if isNil(val): new(val)
   s.unpack(val[])
 

--- a/tests/test_codec.nim
+++ b/tests/test_codec.nim
@@ -614,6 +614,31 @@ suite "msgpack encoder-decoder":
     discard pack(rr)
     discard pack(tt)
 
+  test "ref and value mixed, the first element is null":
+    type
+      CustomType = object
+        strref: ref string
+        str: string
+
+    var
+      o = CustomType(str: "str")
+      s = MsgStream.init()
+
+    s.pack(o)
+
+    check:
+      s.data.stringify == """[ null, "str" ] """
+
+    var
+      ss = MsgStream.init(s.data)
+      oo: CustomType
+
+    ss.unpack(oo)
+
+    check:
+      oo.strref == nil
+      oo.str == o.str
+
   test "inheritance":
     type
       KAB = object of RootObj


### PR DESCRIPTION
Before this change, unpacking not null value after null is incorrect.

## Situation
Unpack `[ null, "str" ]` and deserialize to value of

```nim
type
  CustomType = object
    strref: ref string
    str: string
```

## Expected result

```nim
CustomType(str: "str")
```

## Current result
```nim
CustomType(str: "")
```