### PR TITLE
raise error if not enough bytes for string

### DIFF
--- a/msgpack4nim.nim
+++ b/msgpack4nim.nim
@@ -97,7 +97,7 @@ proc readStr*(s: MsgStream, length: int): string =
   result = newString(length)
   if length != 0:
     var L = s.readData(addr(result[0]), length)
-    doAssert(L == length, "string len mismatch")
+    if L != length: raise newException(IOError, "string len mismatch")
 
 proc readChar*(s: MsgStream): char =
   s.read(result)

--- a/msgpack4nim.nim
+++ b/msgpack4nim.nim
@@ -97,7 +97,7 @@ proc readStr*(s: MsgStream, length: int): string =
   result = newString(length)
   if length != 0:
     var L = s.readData(addr(result[0]), length)
-    if L != length: result.setLen(L)
+    doAssert(L == length, "string len mismatch")
 
 proc readChar*(s: MsgStream): char =
   s.read(result)

--- a/tests/test_codec.nim
+++ b/tests/test_codec.nim
@@ -267,7 +267,7 @@ suite "msgpack encoder-decoder":
         ss = MsgStream.init(s.data[0..i])
         oo: string
 
-      expect(AssertionError):
+      expect(IOError):
         ss.unpack(oo)
 
   test "float number":

--- a/tests/test_codec.nim
+++ b/tests/test_codec.nim
@@ -252,6 +252,24 @@ suite "msgpack encoder-decoder":
     check gg == g
     check hh == h
 
+  test "partial string raise error":
+    var
+      s = MsgStream.init()
+      o = "string"
+
+    s.pack(o)
+
+    check:
+      s.data.stringify == "\"string\" "
+
+    for i in 0..<s.data.len - 1:
+      var
+        ss = MsgStream.init(s.data[0..i])
+        oo: string
+
+      expect(AssertionError):
+        ss.unpack(oo)
+
   test "float number":
     var xx = [-1.0'f32, -2.0, 0.0, Inf, NegInf, 1.0, 2.0]
 


### PR DESCRIPTION
Before this change, string is unpacked incorrectly if there is not enough bytes for string.

## Situation
There is not enough bytes for string.

## Expected behavior
Raise AssertionError.

## Current behavior
Unpack string with partial bytes, and continue deserializing.