### PR TITLE
replace `shallowCopy` with sink parameters

### DIFF
--- a/msgpack4nim.nim
+++ b/msgpack4nim.nim
@@ -48,9 +48,9 @@ proc init*(x: typedesc[MsgStream], cap: int = 0, encodingMode = MSGPACK_OBJ_TO_D
   result.pos = 0
   result.encodingMode = encodingMode
 
-proc init*(x: typedesc[MsgStream], data: string, encodingMode = MSGPACK_OBJ_TO_DEFAULT): MsgStream =
+proc init*(x: typedesc[MsgStream], data: sink string, encodingMode = MSGPACK_OBJ_TO_DEFAULT): MsgStream =
   result = new(x)
-  shallowCopy(result.data, data)
+  result.data = data
   result.pos = 0
   result.encodingMode = encodingMode
 
@@ -73,9 +73,8 @@ proc writeData(s: MsgStream, buffer: pointer, bufLen: int) =
   copyMem(addr(s.data[s.pos]), buffer, bufLen)
   inc(s.pos, bufLen)
 
-proc write*[T](s: MsgStream, val: T) =
-  var y: T
-  shallowCopy(y, val)
+proc write*[T](s: MsgStream, val: sink T) =
+  var y = val
   writeData(s, addr(y), sizeof(y))
 
 proc write*(s: MsgStream, val: string) =

--- a/msgpack4nim.nim
+++ b/msgpack4nim.nim
@@ -793,14 +793,9 @@ proc unpack_string*[ByteStream](s: ByteStream): int =
     result = int(s.unstore32())
 
 proc unpack_type*[ByteStream](s: ByteStream, val: var string) =
-  when compiles(isNil(val)):
-    if s.peekChar == pack_value_nil:
-      val = nil
-      return
-  else:
-    if s.peekChar == pack_value_nil:
-      val = ""
-      return
+  if s.peekChar == pack_value_nil:
+    val = ""
+    return
 
   let len = s.unpack_string()
   if len < 0: raise conversionError("string")


### PR DESCRIPTION
Hello, `shallowCopy` has been removed for ARC/ORC since it does a deep copy with ARC/ORC → https://github.com/nim-lang/Nim/pull/20070

ref https://github.com/nim-lang/Nim/pull/19972